### PR TITLE
fix: change the default currency symbol to the alternate_symbols

### DIFF
--- a/currency.go
+++ b/currency.go
@@ -6,24 +6,23 @@ import (
 
 func init() {
 	// Need to change Currency TWD Fraction from 2 to 0 in /Rhymond/go-money
-	gomoney.AddCurrency("HKD", "$", "$1", ".", ",", 2)
-	gomoney.AddCurrency("HKD", "$", "$1", ".", ",", 2)
-	gomoney.AddCurrency("CNY", "\u00a5", "$1", ".", ",", 2)
+	gomoney.AddCurrency("HKD", "HK$", "$1", ".", ",", 2)
+	gomoney.AddCurrency("CNY", "CN\u00a5", "$1", ".", ",", 2)
 	gomoney.AddCurrency("TWD", "NT$", "$1", ".", ",", 0)
-	gomoney.AddCurrency("USD", "$", "$1", ".", ",", 2)
-	gomoney.AddCurrency("SGD", "$", "$1", ".", ",", 2)
+	gomoney.AddCurrency("USD", "US$", "$1", ".", ",", 2)
+	gomoney.AddCurrency("SGD", "S$", "$1", ".", ",", 2)
 	gomoney.AddCurrency("EUR", "\u20ac", "$1", ".", ",", 2)
-	gomoney.AddCurrency("AUD", "$", "$1", ".", ",", 2)
+	gomoney.AddCurrency("AUD", "A$", "$1", ".", ",", 2)
 	gomoney.AddCurrency("GBP", "\u00a3", "$1", ".", ",", 2)
-	gomoney.AddCurrency("PHP", "\u20b1", "$1", ".", ",", 2)
+	gomoney.AddCurrency("PHP", "PHP", "$1", ".", ",", 2) // \u20b1
 	gomoney.AddCurrency("MYR", "RM", "$1", ".", ",", 2)
 	gomoney.AddCurrency("THB", "\u0e3f", "1 $", ".", ",", 2)
-	gomoney.AddCurrency("AED", "\u062f.\u0625", "1$", ".", ",", 2)
-	gomoney.AddCurrency("JPY", "\u00a5", "$1", ".", ",", 0)
+	gomoney.AddCurrency("AED", "DH", "1$", ".", ",", 2) //\u062f.\u0625
+	gomoney.AddCurrency("JPY", "円", "$1", ".", ",", 0)  // \u00a5
 	gomoney.AddCurrency("MMK", "K", "$1", ".", ",", 2)
-	gomoney.AddCurrency("BND", "$", "$1", ".", ",", 2)
+	gomoney.AddCurrency("BND", "B$", "$1", ".", ",", 2)
 	gomoney.AddCurrency("KRW", "\u20a9", "$1", ".", ",", 0)
 	gomoney.AddCurrency("IDR", "Rp", "$ 1", ",", ".", 2)
 	gomoney.AddCurrency("VND", "\u20ab", "1 $", ".", ",", 0)
-	gomoney.AddCurrency("CAD", "$", "$1", ".", ",", 2)
+	gomoney.AddCurrency("CAD", "C$", "$1", ".", ",", 2)
 }

--- a/money.go
+++ b/money.go
@@ -126,6 +126,13 @@ func (m *Money) Display() string {
 	return m.money.Display()
 }
 
+func (m *Money) Display_v2(showZero bool) string {
+	if showZero {
+		return m.money.Display()
+	}
+	return ""
+}
+
 // Equals checks equality between two Money types.
 func (m *Money) Equals(om *Money) (bool, error) {
 	m.initMoney()

--- a/money.go
+++ b/money.go
@@ -67,7 +67,7 @@ func newFromGoMoney(nm *gomoney.Money, options ...MoneyOption) *Money {
 		CurrencyIso:    nm.Currency().Code,
 		CurrencySymbol: nm.Currency().Grapheme,
 		Label:          nm.Display(),
-		roundingMode:   RoundBankers, // Default Round Mode will be RoundBankers        // Default show zero will be true
+		roundingMode:   RoundBankers, // Default Round Mode will be RoundBankers
 	}
 	for _, option := range options {
 		option(money)

--- a/money.go
+++ b/money.go
@@ -126,11 +126,13 @@ func (m *Money) Display() string {
 	return m.money.Display()
 }
 
+// New Display function for supporting show zero; if true, show zero otherwise return ""
 func (m *Money) Display_v2(showZero bool) string {
-	if showZero {
-		return m.money.Display()
+	if m.money.IsZero() && !showZero {
+		return ""
 	}
-	return ""
+	return m.money.Display()
+
 }
 
 // Equals checks equality between two Money types.

--- a/money_test.go
+++ b/money_test.go
@@ -176,11 +176,6 @@ func TestDisplay(t *testing.T) {
 		expected string
 	}{
 		{
-			cents:    0,
-			currency: "HKD",
-			expected: "HK$1,000.00",
-		},
-		{
 			cents:    100000,
 			currency: "HKD",
 			expected: "HK$1,000.00",
@@ -280,6 +275,35 @@ func TestDisplay(t *testing.T) {
 		m := New(item.cents, item.currency, WithRoundingMode(RoundDown))
 		nm := m.Display()
 		assert.Equal(t, item.expected, nm, item.currency)
+	}
+}
+
+func TestDisplay_v2(t *testing.T) {
+	testTable := []struct {
+		cents                   int64
+		currency                string
+		expected_showZero_true  string
+		expected_showZero_false string
+	}{
+		{
+			cents:                   0,
+			currency:                "HKD",
+			expected_showZero_true:  "HK$0.00",
+			expected_showZero_false: "",
+		},
+		{
+			cents:                   10000,
+			currency:                "CAD",
+			expected_showZero_true:  "C$100.00",
+			expected_showZero_false: "C$100.00",
+		},
+	}
+	for _, item := range testTable {
+		m := New(item.cents, item.currency, WithRoundingMode(RoundDown))
+		nm1 := m.Display_v2(true)
+		nm2 := m.Display_v2(false)
+		assert.Equal(t, item.expected_showZero_true, nm1, item.currency)
+		assert.Equal(t, item.expected_showZero_false, nm2, item.currency)
 	}
 }
 

--- a/money_test.go
+++ b/money_test.go
@@ -24,8 +24,8 @@ func TestFromAmount(t *testing.T) {
 	assert.Equal(t, int64(10000), hkdM.Cents)
 	assert.Equal(t, RoundBankers, hkdM.GetRoundingMode())
 	assert.Equal(t, "HKD", hkdM.CurrencyIso)
-	assert.Equal(t, "$", hkdM.CurrencySymbol)
-	assert.Equal(t, "$100.00", hkdM.Label)
+	assert.Equal(t, "HK$", hkdM.CurrencySymbol)
+	assert.Equal(t, "HK$100.00", hkdM.Label)
 
 	jpyM := NewFromAmount(100, "JPY")
 	assert.Equal(t, int64(100), jpyM.Cents)
@@ -35,7 +35,7 @@ func TestFromAmount(t *testing.T) {
 	assert.Equal(t, int64(2855), usdM.Cents)
 	assert.Equal(t, 28.55, usdM.Dollars)
 	assert.Equal(t, RoundUp, usdM.GetRoundingMode())
-	assert.Equal(t, "$28.55", usdM.Label)
+	assert.Equal(t, "US$28.55", usdM.Label)
 
 	twdM := NewFromAmount(28.55, "TWD", WithRoundingMode(RoundUp))
 	assert.Equal(t, int64(29), twdM.Cents)
@@ -178,12 +178,12 @@ func TestDisplay(t *testing.T) {
 		{
 			cents:    100000,
 			currency: "HKD",
-			expected: "$1,000.00",
+			expected: "HK$1,000.00",
 		},
 		{
 			cents:    100000,
 			currency: "CNY",
-			expected: "¥1,000.00",
+			expected: "CN¥1,000.00",
 		},
 		{
 			cents:    100000,
@@ -193,12 +193,12 @@ func TestDisplay(t *testing.T) {
 		{
 			cents:    100000,
 			currency: "USD",
-			expected: "$1,000.00",
+			expected: "US$1,000.00",
 		},
 		{
 			cents:    100000,
 			currency: "SGD",
-			expected: "$1,000.00",
+			expected: "S$1,000.00",
 		},
 		{
 			cents:    100000,
@@ -208,7 +208,7 @@ func TestDisplay(t *testing.T) {
 		{
 			cents:    100000,
 			currency: "AUD",
-			expected: "$1,000.00",
+			expected: "A$1,000.00",
 		},
 		{
 			cents:    100000,
@@ -218,7 +218,7 @@ func TestDisplay(t *testing.T) {
 		{
 			cents:    100000,
 			currency: "PHP",
-			expected: "₱1,000.00",
+			expected: "PHP1,000.00",
 		},
 		{
 			cents:    100000,
@@ -233,12 +233,12 @@ func TestDisplay(t *testing.T) {
 		{
 			cents:    100000,
 			currency: "AED",
-			expected: "1,000.00د.إ",
+			expected: "1,000.00DH",
 		},
 		{
 			cents:    100000,
 			currency: "JPY",
-			expected: "¥100,000",
+			expected: "円100,000",
 		},
 		{
 			cents:    100000,
@@ -248,7 +248,7 @@ func TestDisplay(t *testing.T) {
 		{
 			cents:    100000,
 			currency: "BND",
-			expected: "$1,000.00",
+			expected: "B$1,000.00",
 		},
 		{
 			cents:    100000,
@@ -268,7 +268,7 @@ func TestDisplay(t *testing.T) {
 		{
 			cents:    100000,
 			currency: "CAD",
-			expected: "$1,000.00",
+			expected: "C$1,000.00",
 		},
 	}
 	for _, item := range testTable {

--- a/money_test.go
+++ b/money_test.go
@@ -16,7 +16,6 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, "TWD", m.CurrencyIso)
 	assert.Equal(t, "NT$", m.CurrencySymbol)
 	assert.Equal(t, "NT$100", m.Label)
-	assert.Equal(t, true, m.showZero)
 }
 
 func TestFromAmount(t *testing.T) {
@@ -51,20 +50,9 @@ func TestSetRoundingMode(t *testing.T) {
 	assert.Equal(t, RoundDown, m.roundingMode)
 }
 
-func TestSetShowZero(t *testing.T) {
-	m := New(100, "TWD", WithShowZero(true))
-	m.SetShowZero(false)
-	assert.Equal(t, false, m.showZero)
-}
-
 func TestGetRoundingMode(t *testing.T) {
 	m := New(100, "TWD", WithRoundingMode(RoundUp))
 	assert.Equal(t, RoundUp, m.GetRoundingMode())
-}
-
-func TestGetShowZero(t *testing.T) {
-	m := New(100, "TWD", WithRoundingMode(RoundUp), WithShowZero(false))
-	assert.Equal(t, false, m.GetShowZero())
 }
 
 func TestInitMoney(t *testing.T) {
@@ -310,12 +298,14 @@ func TestDisplay_WithShowZero(t *testing.T) {
 		},
 	}
 	for _, item := range testTable {
-		m1 := New(item.cents, item.currency, WithRoundingMode(RoundDown))
-		m2 := New(item.cents, item.currency, WithRoundingMode(RoundDown), WithShowZero(false))
-		nm1 := m1.Display()
-		nm2 := m2.Display()
+		m := New(item.cents, item.currency, WithRoundingMode(RoundDown))
+
+		nm1 := m.Display()
+		nm2 := m.Display(func(opts *DisplayOptions) { opts.ShowZero = false })
+		nm3 := m.Display(func(opts *DisplayOptions) { opts.ShowZero = true })
 		assert.Equal(t, item.expected_showZero_true, nm1, item.currency)
 		assert.Equal(t, item.expected_showZero_false, nm2, item.currency)
+		assert.Equal(t, item.expected_showZero_true, nm3, item.currency)
 	}
 }
 
@@ -738,14 +728,6 @@ func TestAdd_DifferentCurrencies(t *testing.T) {
 	assert.Equal(t, "currencies don't match", err.Error())
 }
 
-func TestAdd_DifferentShowZero(t *testing.T) {
-	m1 := New(0, "USD", WithRoundingMode(RoundDown), WithShowZero(false))
-	m2 := New(0, "USD", WithRoundingMode(RoundDown), WithShowZero(true))
-	nm, err := m1.Add(m2)
-	assert.NoError(t, err)
-	assert.Equal(t, false, nm.GetShowZero())
-}
-
 func TestSubtract_SingleValue(t *testing.T) {
 	testTable := []struct {
 		cents1   int64
@@ -820,14 +802,6 @@ func TestSubtract_DifferentCurrencies(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, nm)
 	assert.Equal(t, "currencies don't match", err.Error())
-}
-
-func TestSubtract_DifferentShowZero(t *testing.T) {
-	m1 := New(0, "USD", WithRoundingMode(RoundDown), WithShowZero(false))
-	m2 := New(0, "USD", WithRoundingMode(RoundDown), WithShowZero(true))
-	nm, err := m1.Subtract(m2)
-	assert.NoError(t, err)
-	assert.Equal(t, false, nm.GetShowZero())
 }
 
 func TestMultiply(t *testing.T) {

--- a/money_test.go
+++ b/money_test.go
@@ -176,6 +176,11 @@ func TestDisplay(t *testing.T) {
 		expected string
 	}{
 		{
+			cents:    0,
+			currency: "HKD",
+			expected: "HK$1,000.00",
+		},
+		{
 			cents:    100000,
 			currency: "HKD",
 			expected: "HK$1,000.00",

--- a/money_test.go
+++ b/money_test.go
@@ -16,6 +16,7 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, "TWD", m.CurrencyIso)
 	assert.Equal(t, "NT$", m.CurrencySymbol)
 	assert.Equal(t, "NT$100", m.Label)
+	assert.Equal(t, true, m.showZero)
 }
 
 func TestFromAmount(t *testing.T) {
@@ -50,10 +51,20 @@ func TestSetRoundingMode(t *testing.T) {
 	assert.Equal(t, RoundDown, m.roundingMode)
 }
 
+func TestSetShowZero(t *testing.T) {
+	m := New(100, "TWD", WithShowZero(true))
+	m.SetShowZero(false)
+	assert.Equal(t, false, m.showZero)
+}
+
 func TestGetRoundingMode(t *testing.T) {
 	m := New(100, "TWD", WithRoundingMode(RoundUp))
-	m.GetRoundingMode()
-	assert.Equal(t, RoundUp, m.roundingMode)
+	assert.Equal(t, RoundUp, m.GetRoundingMode())
+}
+
+func TestGetShowZero(t *testing.T) {
+	m := New(100, "TWD", WithRoundingMode(RoundUp), WithShowZero(false))
+	assert.Equal(t, false, m.GetShowZero())
 }
 
 func TestInitMoney(t *testing.T) {
@@ -278,7 +289,7 @@ func TestDisplay(t *testing.T) {
 	}
 }
 
-func TestDisplay_v2(t *testing.T) {
+func TestDisplay_WithShowZero(t *testing.T) {
 	testTable := []struct {
 		cents                   int64
 		currency                string
@@ -299,9 +310,10 @@ func TestDisplay_v2(t *testing.T) {
 		},
 	}
 	for _, item := range testTable {
-		m := New(item.cents, item.currency, WithRoundingMode(RoundDown))
-		nm1 := m.Display_v2(true)
-		nm2 := m.Display_v2(false)
+		m1 := New(item.cents, item.currency, WithRoundingMode(RoundDown))
+		m2 := New(item.cents, item.currency, WithRoundingMode(RoundDown), WithShowZero(false))
+		nm1 := m1.Display()
+		nm2 := m2.Display()
 		assert.Equal(t, item.expected_showZero_true, nm1, item.currency)
 		assert.Equal(t, item.expected_showZero_false, nm2, item.currency)
 	}
@@ -726,6 +738,14 @@ func TestAdd_DifferentCurrencies(t *testing.T) {
 	assert.Equal(t, "currencies don't match", err.Error())
 }
 
+func TestAdd_DifferentShowZero(t *testing.T) {
+	m1 := New(0, "USD", WithRoundingMode(RoundDown), WithShowZero(false))
+	m2 := New(0, "USD", WithRoundingMode(RoundDown), WithShowZero(true))
+	nm, err := m1.Add(m2)
+	assert.NoError(t, err)
+	assert.Equal(t, false, nm.GetShowZero())
+}
+
 func TestSubtract_SingleValue(t *testing.T) {
 	testTable := []struct {
 		cents1   int64
@@ -800,6 +820,14 @@ func TestSubtract_DifferentCurrencies(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, nm)
 	assert.Equal(t, "currencies don't match", err.Error())
+}
+
+func TestSubtract_DifferentShowZero(t *testing.T) {
+	m1 := New(0, "USD", WithRoundingMode(RoundDown), WithShowZero(false))
+	m2 := New(0, "USD", WithRoundingMode(RoundDown), WithShowZero(true))
+	nm, err := m1.Subtract(m2)
+	assert.NoError(t, err)
+	assert.Equal(t, false, nm.GetShowZero())
 }
 
 func TestMultiply(t *testing.T) {


### PR DESCRIPTION
According to the function to_hash, the default symbol of the currency should be using first item of alternate_symbols in json instead of symbol

Also, we have add function display_v2 which can set show zero or not it the output

### Reference:
**sl-util**
https://bitbucket.org/starlinglabs/sl-utils/src/master/lib/sl-utils/money_ext.rb
**RubyMoney**
https://github.com/RubyMoney/money/blob/9c5f223491dd6edb1085f7efc98c4d139fe94e8b/config/currency_iso.json
**sl-utils-node**
https://bitbucket.org/starlinglabs/sl-utils-node/src/master/lib/models/Currency/index.js